### PR TITLE
Draft:  Add multiplication support for keep dice

### DIFF
--- a/parser/src/main/kotlin/DiceRollingVisitor.kt
+++ b/parser/src/main/kotlin/DiceRollingVisitor.kt
@@ -139,6 +139,14 @@ class DiceRollingVisitor(private val randomGenerator: (Int) -> Int) : DiceVisito
         return ResultTree(keepLowDice, values.map { it.value }.sorted().take(keepLowDice.numberToKeep).stream().reduce { x, y -> Math.addExact(x, y) }.get(), values)
     }
 
+    override fun visit(keepLowDiceMul: KeepLowDiceMul): ResultTree {
+        val values = IntRange(1, keepLowDiceMul.numberOfDice)
+                .map { random(keepLowDiceMul.numberOfFaces) }
+                .map { ResultTree(NDice(keepLowDiceMul.numberOfFaces), it) }
+
+        return ResultTree(keepLowDiceMul, values.map { it.value }.sorted().take(keepLowDiceMul.numberToKeep).stream().reduce { x, y -> Math.multiplyExact(x, y) }.get(), values)
+    }
+
     override fun visit(explodingDice: ExplodingDice): ResultTree {
         val values = explodeRoll(explodingDice.numberOfDice, explodingDice.numberOfFaces, predicate(explodingDice.comparison, explodingDice.target))
                 .map { ResultTree(NDice(explodingDice.numberOfFaces), it) }

--- a/parser/src/main/kotlin/DiceTypes.kt
+++ b/parser/src/main/kotlin/DiceTypes.kt
@@ -58,6 +58,12 @@ class KeepLowDice(numberOfFaces: Int, numberOfDice: Int, val numberToKeep: Int) 
     }
 }
 
+class KeepLowDiceMul(numberOfFaces: Int, numberOfDice: Int, val numberToKeep: Int) : BaseDiceExpression(numberOfFaces, numberOfDice) {
+    override fun description(): String {
+        return "${numberOfDice}d${numberOfFaces}l${numberToKeep}X"
+    }
+}
+
 class ExplodingDice(numberOfFaces: Int, numberOfDice: Int, val comparison: Comparison = Comparison.EQUAL_TO, val target: Int = numberOfFaces) : BaseDiceExpression(numberOfFaces, numberOfDice) {
     override fun description(): String {
         val extra = if (numberOfFaces == target && comparison == Comparison.EQUAL_TO) {

--- a/parser/src/main/kotlin/DiceVisitor.kt
+++ b/parser/src/main/kotlin/DiceVisitor.kt
@@ -30,6 +30,7 @@ interface DiceVisitor<T> {
             is TargetPoolDice -> visit(diceExpression)
             is KeepDice -> visit(diceExpression)
             is KeepLowDice -> visit(diceExpression)
+            is KeepLowDiceMul -> visit(diceExpression)
             is NegativeDiceExpression -> visit(diceExpression)
             is SortedDiceExpression -> visit(diceExpression)
             is MinDiceExpression -> visit(diceExpression)
@@ -57,6 +58,8 @@ interface DiceVisitor<T> {
     fun visit(targetPoolDice: TargetPoolDice): T
 
     fun visit(keepLowDice: KeepLowDice): T
+
+    fun visit(keepLowDiceMul: KeepLowDiceMul): T
 
     fun visit(negativeDiceExpression: NegativeDiceExpression): T
 

--- a/parser/src/main/kotlin/impl/RegexDice.kt
+++ b/parser/src/main/kotlin/impl/RegexDice.kt
@@ -48,7 +48,8 @@ class RegexDice {
         private val EXPLODE_DICE = "$N_DICE_FACE$BANG" // 3d6!
         private val EXPLODE_DICE_TARGET = "$EXPLODE_DICE(?<comp>[$LESS_THEN_EQUAL$GREATER_THEN_EQUAL$EQUAL]?)(?<target>$INT)" // 3d6!>5 or 3d6!5
         private val KEEP_DICE = Regex("$N_DICE_FACE$K(?<keep>$INT)") // 4d6k2
-        private val KEEP_LOW_DICE = Regex("$N_DICE_FACE$L(?<keep>$INT)") // 4d6k2
+        private val KEEP_LOW_DICE = Regex("$N_DICE_FACE$L(?<keep>$INT)") // 4d6l2
+        private val KEEP_LOW_DICE_MUL = Regex("$N_DICE_FACE$L(?<keep>$INT)X") // 4d6l2X
         private val TARGET_POOL = "$N_DICE_FACE(?<operator>[$LESS_THEN_EQUAL$GREATER_THEN_EQUAL$EQUAL])(?<target>$INT)" // 4d10>6
         private val TARGET_POOL_PARENS = "$LPAREN$N_DICE_FACE(?<operation>[+-]?)(?<modifier>$INT)$RPAREN(?<operator>[$LESS_THEN_EQUAL$GREATER_THEN_EQUAL$EQUAL])(?<target>$INT)" // (4d10+2)>6
         private val NESTED = "(?<LEFT>.*)$LPAREN(?<NESTED>.*)$RPAREN(?<RIGHT>.*)".toRegex() // 10(2) or (2) or 10(2)4
@@ -67,6 +68,7 @@ class RegexDice {
             N_DICE_FACE.toRegex() to this::visitNDiceFace,
             KEEP_DICE to this::visitKeepDice,
             KEEP_LOW_DICE to this::visitKeepLowDice,
+            KEEP_LOW_DICE_MUL to this::visitKeepLowDiceMul,
             DICE_FACE.toRegex() to this::visitDiceFace,
             DICE_FACE_X.toRegex() to this::visitDiceFaceX,
             N_DICE_FACE_X.toRegex() to this::visitNDiceFaceX,
@@ -228,6 +230,14 @@ class RegexDice {
         val numberToKeep = match.groupValues[3].toInt()
 
         return KeepLowDice(numberOfFaces, numberOfDice, numberToKeep)
+    }
+
+    private fun visitKeepLowDiceMul(match: MatchResult): DiceExpression {
+        val numberOfDice = match.groupValues[1].toInt()
+        val numberOfFaces = match.groupValues[2].toInt()
+        val numberToKeep = match.groupValues[3].toInt()
+
+        return KeepLowDiceMul(numberOfFaces, numberOfDice, numberToKeep)
     }
 
     fun comparisonFrom(text: String): Comparison {

--- a/parser/src/test/kotlin/RegexDiceTest.kt
+++ b/parser/src/test/kotlin/RegexDiceTest.kt
@@ -218,6 +218,13 @@ class RegexDiceTest {
         expect(108) { parse("(100 + 2d6) max (2 *2)", rolls(2, 6)) }
     }
 
+    @Test
+    fun multiplyLowest() {
+        expect(6) { parse("4d6l2X", rolls(2,3,4,5)) }
+        expect(4) { parse("4d6l2X", rolls(2,2,4,5)) }
+        expect(8) { parse("4d6l2X", rolls(6,2,4,5)) }
+    }
+
     private fun parse(expression: String): Int {
         val diceExpression = RegexDice().parse(expression)
         val result = DiceRollingVisitor { it }.visit(diceExpression)


### PR DESCRIPTION
TODO: This only works for lowest right now.  This needs to be reworked to support both highest and lowest keep options. But possibly more generically any dice result, not sure which expressions need to support this yet

Fixes: #55
